### PR TITLE
feat: Add support to multipart

### DIFF
--- a/expected-template.json
+++ b/expected-template.json
@@ -1,0 +1,60 @@
+{
+  "uuid": "%s",
+  "id": "%s",
+  "priority": 1,
+  "scenarioName": "Scenario",
+  "requiredScenarioState": "Started",
+  "newScenarioState": "Stopped",
+  "request": {
+    "basicAuthCredentials": {
+      "password": "password",
+      "username": "username"
+    },
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"meta\": \"information\"}"
+      },
+      {
+        "contains": "information"
+      }
+    ],
+    "multipartPatterns": [
+      {
+        "matchingType": "ANY",
+        "bodyPatterns": [
+          {
+            "contains": "test"
+          }
+        ]
+      }
+    ],
+    "cookies": {
+      "session": {
+        "equalToXml": "\u003cxml\u003e"
+      }
+    },
+    "headers": {
+      "x-session": {
+        "matches": "^\\S+@\\S+$"
+      }
+    },
+    "method": "POST",
+    "queryParameters": {
+      "firstName": {
+        "equalTo": "Jhon"
+      },
+      "lastName": {
+        "doesNotMatch": "Black"
+      }
+    },
+    "urlPath": "/example"
+  },
+  "response": {
+    "body": "{\"code\": 400, \"detail\": \"detail\"}",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 400,
+    "fixedDelayMilliseconds": 5000
+  }
+}

--- a/request.go
+++ b/request.go
@@ -4,14 +4,23 @@ import (
 	"encoding/json"
 )
 
+type requestType int
+
+const (
+	requestTypeMain requestType = iota
+	requestTypeSubRequest
+)
+
 // A Request is the part of StubRule describing the matching of the http request
 type Request struct {
+	requestType          requestType
 	urlMatcher           URLMatcherInterface
 	method               string
 	headers              map[string]ParamMatcherInterface
 	queryParams          map[string]ParamMatcherInterface
 	cookies              map[string]ParamMatcherInterface
 	bodyPatterns         []ParamMatcher
+	multipartPatterns    []Request
 	basicAuthCredentials *struct {
 		username string
 		password string
@@ -21,8 +30,9 @@ type Request struct {
 // NewRequest constructs minimum possible Request
 func NewRequest(method string, urlMatcher URLMatcherInterface) *Request {
 	return &Request{
-		method:     method,
-		urlMatcher: urlMatcher,
+		requestType: requestTypeMain,
+		method:      method,
+		urlMatcher:  urlMatcher,
 	}
 }
 
@@ -41,6 +51,16 @@ func (r *Request) WithURLMatched(urlMatcher URLMatcherInterface) *Request {
 // WithBodyPattern adds body pattern to list
 func (r *Request) WithBodyPattern(matcher ParamMatcher) *Request {
 	r.bodyPatterns = append(r.bodyPatterns, matcher)
+	return r
+}
+
+// WithMultipartPattern adds body pattern to list
+func (r *Request) WithMultipartPattern(matcher func(request *Request)) *Request {
+	request := Request{
+		requestType: requestTypeSubRequest,
+	}
+	matcher(&request)
+	r.multipartPatterns = append(r.multipartPatterns, request)
 	return r
 }
 
@@ -88,9 +108,16 @@ func (r *Request) WithCookie(cookie string, matcher ParamMatcherInterface) *Requ
 
 // MarshalJSON gives valid JSON or error.
 func (r *Request) MarshalJSON() ([]byte, error) {
-	request := map[string]interface{}{
-		"method":                        r.method,
-		string(r.urlMatcher.Strategy()): r.urlMatcher.Value(),
+	return json.Marshal(r.toJsonRequest())
+}
+
+func (r *Request) toJsonRequest() map[string]interface{} {
+	request := make(map[string]interface{})
+	if r.requestType == requestTypeMain {
+		request["method"] = r.method
+		request[string(r.urlMatcher.Strategy())] = r.urlMatcher.Value()
+	} else {
+		request["matchingType"] = "ANY"
 	}
 	if len(r.bodyPatterns) > 0 {
 		bodyPatterns := make([]map[ParamMatchingStrategy]string, len(r.bodyPatterns))
@@ -101,6 +128,14 @@ func (r *Request) MarshalJSON() ([]byte, error) {
 		}
 		request["bodyPatterns"] = bodyPatterns
 	}
+	if len(r.multipartPatterns) > 0 {
+		multipartPatterns := make([]map[string]interface{}, len(r.multipartPatterns))
+		for i, multipartPattern := range r.multipartPatterns {
+			jsonRequest := multipartPattern.toJsonRequest()
+			multipartPatterns[i] = jsonRequest
+		}
+		request["multipartPatterns"] = multipartPatterns
+	}
 	if len(r.headers) > 0 {
 		headers := make(map[string]map[ParamMatchingStrategy]string, len(r.bodyPatterns))
 		for key, header := range r.headers {
@@ -109,6 +144,10 @@ func (r *Request) MarshalJSON() ([]byte, error) {
 			}
 		}
 		request["headers"] = headers
+	}
+	// multipartPatterns are a mini http but only supports bodyPatterns and headers
+	if r.requestType == requestTypeSubRequest {
+		return request
 	}
 	if len(r.cookies) > 0 {
 		cookies := make(map[string]map[ParamMatchingStrategy]string, len(r.cookies))
@@ -135,6 +174,5 @@ func (r *Request) MarshalJSON() ([]byte, error) {
 			"username": r.basicAuthCredentials.username,
 		}
 	}
-
-	return json.Marshal(request)
+	return request
 }

--- a/stub_rule.go
+++ b/stub_rule.go
@@ -81,6 +81,12 @@ func (s *StubRule) WithBodyPattern(matcher ParamMatcher) *StubRule {
 	return s
 }
 
+// WithMultipartPattern adds a multipart pattern and returns *StubRule
+func (s *StubRule) WithMultipartPattern(f func(request *Request)) *StubRule {
+	s.request.WithMultipartPattern(f)
+	return s
+}
+
 // WillReturn sets response and returns *StubRule
 func (s *StubRule) WillReturn(body string, headers map[string]string, status int64) *StubRule {
 	s.response.body = body


### PR DESCRIPTION
This is done by reusing the whole request logic but, when serializing only headers and body matchers are used.
